### PR TITLE
Send suffix for shortener to make always unguessable links

### DIFF
--- a/js/shortener.js
+++ b/js/shortener.js
@@ -3,11 +3,14 @@
 // Param 2: The API key
 // Param 3: The successfull callback (function) which will return the shortUrl as param
 function createShortUrl(longUrl, apiKey, callback) {
-  var req = new Object();
   var linkInfo = new Object();
   linkInfo.domainUriPrefix = "URL_PREFIX.page.link"
   linkInfo.link = longUrl
+  var suffix = new Object();
+  suffix.option = "UNGUESSABLE"
+  var req = new Object();
   req.dynamicLinkInfo = linkInfo
+  req.suffix = suffix
   var jsonBody = JSON.stringify(req);
 
   var xhr = new XMLHttpRequest();


### PR DESCRIPTION
According to the documentation the default behaviour is to create UNGUESSABLE links.
See https://firebase.google.com/docs/dynamic-links/rest:
![Bildschirmfoto 2019-08-20 um 13 35 57](https://user-images.githubusercontent.com/10229883/63343912-7ab49b00-c34f-11e9-980e-40e8bf79332e.png)

I just discovered that this is not true (anymore?).. Or maybe a bug.
Whatever..
This change makes sure that we will always receive UNGUESABLE links...